### PR TITLE
Modified shebang line to be more specific

### DIFF
--- a/quickhist/quickhist
+++ b/quickhist/quickhist
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # Copyright (c) 2015 Nagarjuna Kumarappan
 #


### PR DESCRIPTION
Depending on the users OS/Distro python could default to python2 or python3. So
it's better to be specific with your shebang.

And judging by the code, you're using python2.